### PR TITLE
Fix two problems(history data, cloud tag)

### DIFF
--- a/src/components/SignUp/EditForm.js
+++ b/src/components/SignUp/EditForm.js
@@ -51,8 +51,7 @@ class EditForm extends Component {
   renderEdit() {
     return (
       <View
-        ref={(component) => { this.editView = component; }
-        }
+        ref={(component) => { this.editView = component; }}
         style={styles.view}
       >
         <TextInput

--- a/src/components/SignUp/GeneralInfo.js
+++ b/src/components/SignUp/GeneralInfo.js
@@ -231,6 +231,22 @@ class GeneralInfo extends Component {
     );
   }
 
+  cleanHistory(historyList, type) {
+    let length = historyList.length;
+    for (let i = 0; i < length; i++) {
+      if (type === 'edu' && !historyList[i].school.name) {
+        historyList.splice(i, 1);
+        length -= 1;
+        i -= 1;
+      } else if (type === 'work' && !historyList[i].employer.name) {
+        historyList.splice(i, 1);
+        length -= 1;
+        i -= 1;
+      }
+    }
+    return historyList;
+  }
+
   // Regist general user info.
   regist() {
     const profile = this.state.profile;
@@ -250,13 +266,16 @@ class GeneralInfo extends Component {
       image = profile.imageResource.data;
     }
 
+    const education = this.cleanHistory(profile.education, 'edu');
+    const experience = this.cleanHistory(profile.experience, 'work');
+
     const fieldSet = {
       name: profile.name,
       email: profile.email,
       location: profile.location,
       about: profile.about || '',
-      education: profile.education,
-      experience: profile.experience,
+      education,
+      experience,
       image,
     };
 

--- a/src/components/userProfile/CloudTag.js
+++ b/src/components/userProfile/CloudTag.js
@@ -80,7 +80,6 @@ export default class CloudTag extends Component {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -89,5 +88,5 @@ const styles = StyleSheet.create({
     flexWrap: 'wrap',
     alignItems: 'center',
     justifyContent: 'center',
-  }
+  },
 });

--- a/src/components/userProfile/UserOverview.js
+++ b/src/components/userProfile/UserOverview.js
@@ -159,7 +159,7 @@ class UserOverview extends Component {
     return (
       <View style={styles.sectionContainer}>
         <Text style={styles.sectionName}>Personality</Text>
-        <CloudTag tagList={tagList} width={250} />
+        <CloudTag tagList={tagList} width={275} />
       </View>
     );
   }


### PR DESCRIPTION
1. a problem(dummy history data) in GeneralInformation
2. a problem(disappearing cloud tag) in UserOverview.

I found another problem.
The problem is about 'ScrollableTabView'.
If first scene's height is 100 and second scene's height is 200,
when I move to second scene and come back to first scene,
current scene's height is 200!
I could find the same issue(https://github.com/skv-headless/react-native-scrollable-tab-view/issues/415) but there are no official patch until now!
I'll try to fix this error.